### PR TITLE
fix form not properly submitting ?url=

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@ SPDX-License-Identifier: Apache-2.0
 	</style>
 </head>
 <body>
-	<form id="previewform" onsubmit="location.href='/?'+this.file.value;return false">
+	<form id="previewform" onsubmit="location.href='/?url='+this.file.value;return false">
 		<h1>Git-Forge HTML Preview</h1>
 		<p>
 			Enter URL of the HTML file to preview:


### PR DESCRIPTION
fixes:
- #4

as much as I agree with other comments that the `?url=` segment is a bit awks, IMO it is best practice to use explicit parameters; it is not as if GH Pages lets you do this anyway This kind of long-term shortcut would be best handled on the host level, e.g. with a Cloudflare redirect `htmlfil.es/(.+) -> https://html-preview.github.io/?url=$1`